### PR TITLE
Fix typo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See the list of [contributors](https://github.com/gpijat/athena/contributors) wh
 
 ## License
 
-This project is licensed under the GPT-3.0 License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the GPL-3.0 License - see the [LICENSE](LICENSE) file for details.
 
 ## More
 


### PR DESCRIPTION
I changed `GPT` to `GPL` to avoid confusion with ChatGPT